### PR TITLE
recursively create themes folder when not exist

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -25,7 +25,7 @@ class Plugin extends Base
 		foreach ($scanned_user_themes as $theme) {
 			$customizer['themes'][rtrim($theme, '.css')] = DATA_DIR . '/files/customizer/themes/' . $theme;
 		}
-	} else { mkdir(DATA_DIR . '/files/customizer/themes', 0755); }	
+	} else { mkdir(DATA_DIR . '/files/customizer/themes', 0755, true); }	
 	    
 	foreach ($scanned_preset_themes as $theme) {
 		$customizer['themes'][rtrim($theme, '.css')] = 'plugins/Customizer/Assets/css/themes/' . $theme;


### PR DESCRIPTION
# Issue
`mkdir()` function on line `28` of `Plugin.php` fails to create themes directory as below:
![screenshot 2019-02-20 21-39-33](https://user-images.githubusercontent.com/30635693/53123555-48b5ae00-3551-11e9-9373-664cb693b5e8.png)
To know: I installed the plugin manually.

# Fix
Enable recursive creation of parent folders in the `mkdir` function call.

