### PR TITLE
Fix bottom border for Breathe theme 

### DIFF
--- a/Assets/css/themes/Breathe.css
+++ b/Assets/css/themes/Breathe.css
@@ -20,7 +20,7 @@ a{
 .sidebar>ul a:hover{
 	color:#007BA8;
 }
-div.task-board-recent {
+div.task-board {
 	box-shadow: none;
 	border-bottom: 6px solid rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
The correct border was only being applied to task with `task-board-recent` and not all task (`.task-board`)