### PR TITLE
Change page-header link color

### DIFF
--- a/Assets/css/themes/Blueboard.css
+++ b/Assets/css/themes/Blueboard.css
@@ -129,7 +129,7 @@ input[type="number"], input[type="date"], input[type="email"], input[type="passw
 }
 
 .page-header a {
-    color: #ffffff;
+    color: #000;
     text-decoration: none;
 }
 


### PR DESCRIPTION
Used to be #ffffff, which was barely visible on background #fbfbfb
Changed it to #000